### PR TITLE
Fixed Implicit Error and Syntax error

### DIFF
--- a/5_ValidIdentifier.y
+++ b/5_ValidIdentifier.y
@@ -5,6 +5,8 @@
 %{
     #include <stdio.h>
     int valid = 1;
+    int yylex();
+    int yyerror();
 %}
 
 %token digit letter

--- a/6_RecognizeGrammar.l
+++ b/6_RecognizeGrammar.l
@@ -22,6 +22,6 @@
 }
 %%
   
-int yywrap(void)) { 
+int yywrap(void) {
     return 1; 
-} 
+}

--- a/6_RecognizeGrammar.y
+++ b/6_RecognizeGrammar.y
@@ -6,6 +6,8 @@
 %{
     #include <stdio.h>
     #include <stdlib.h>
+    int yylex();
+    int yyerror();
 %}
   
 %token A B NL


### PR DESCRIPTION
This stuff
```
y.tab.c:1216:16: error: implicit declaration of function 'yylex' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      yychar = YYLEX;
               ^
y.tab.c:572:16: note: expanded from macro 'YYLEX'
# define YYLEX yylex ()
               ^
y.tab.c:1334:7: error: implicit declaration of function 'yyerror' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      yyerror (YY_("syntax error"));
      ^
y.tab.c:1480:3: error: implicit declaration of function 'yyerror' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  yyerror (YY_("memory exhausted"));
  ^
3 errors generated.
```